### PR TITLE
IterImplForStreaming now check for '+' character. Previously scientif…

### DIFF
--- a/src/main/java/com/jsoniter/IterImplForStreaming.java
+++ b/src/main/java/com/jsoniter/IterImplForStreaming.java
@@ -543,6 +543,7 @@ class IterImplForStreaming {
                 byte c = iter.buf[i];
                 switch (c) {
                     case '-':
+                    case '+':
                     case '.':
                     case 'e':
                     case 'E':

--- a/src/test/java/com/jsoniter/IterImplForStreamingTest.java
+++ b/src/test/java/com/jsoniter/IterImplForStreamingTest.java
@@ -1,0 +1,13 @@
+package com.jsoniter;
+
+import junit.framework.TestCase;
+
+public class IterImplForStreamingTest extends TestCase {
+
+	public void testReadMaxDouble() throws Exception {
+		String maxDouble = "1.7976931348623157e+308";
+		JsonIterator iter = JsonIterator.parse("1.7976931348623157e+308");
+		String number = IterImplForStreaming.readNumber(iter);
+		assertEquals(maxDouble, number);
+	}
+}


### PR DESCRIPTION
…ic notation like "1.0e+10" would fail.