### PR TITLE
fix of overflow detection for numeric primitive types

### DIFF
--- a/src/main/java/com/jsoniter/IterImpl.java
+++ b/src/main/java/com/jsoniter/IterImpl.java
@@ -323,123 +323,136 @@ class IterImpl {
         return bound;
     }
 
-    static final int readPositiveInt(final JsonIterator iter, byte c) throws IOException {
+    static final int readInt(final JsonIterator iter, final byte c, final boolean negative) throws IOException {
         int ind = IterImplNumber.intDigits[c];
         if (ind == 0) {
             IterImplForStreaming.assertNotLeadingZero(iter);
             return 0;
         }
         if (ind == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
-            throw iter.reportError("readPositiveInt", "expect 0~9");
+            throw iter.reportError("readInt", "expect 0~9");
         }
         if (iter.tail - iter.head > 9) {
             int i = iter.head;
             int ind2 = IterImplNumber.intDigits[iter.buf[i]];
             if (ind2 == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
                 iter.head = i;
-                return ind;
+                return negative ? -ind : ind;
             }
             int ind3 = IterImplNumber.intDigits[iter.buf[++i]];
             if (ind3 == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
                 iter.head = i;
-                return ind * 10 + ind2;
+                ind = ind * 10 + ind2;
+                return negative ? -ind : ind;
             }
             int ind4 = IterImplNumber.intDigits[iter.buf[++i]];
             if (ind4 == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
                 iter.head = i;
-                return ind * 100 + ind2 * 10 + ind3;
+                ind = ind * 100 + ind2 * 10 + ind3;
+                return negative ? -ind : ind;
             }
             int ind5 = IterImplNumber.intDigits[iter.buf[++i]];
             if (ind5 == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
                 iter.head = i;
-                return ind * 1000 + ind2 * 100 + ind3 * 10 + ind4;
+                ind = ind * 1000 + ind2 * 100 + ind3 * 10 + ind4;
+                return negative ? -ind : ind;
             }
             int ind6 = IterImplNumber.intDigits[iter.buf[++i]];
             if (ind6 == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
                 iter.head = i;
-                return ind * 10000 + ind2 * 1000 + ind3 * 100 + ind4 * 10 + ind5;
+                ind = ind * 10000 + ind2 * 1000 + ind3 * 100 + ind4 * 10 + ind5;
+                return negative ? -ind : ind;
             }
             int ind7 = IterImplNumber.intDigits[iter.buf[++i]];
             if (ind7 == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
                 iter.head = i;
-                return ind * 100000 + ind2 * 10000 + ind3 * 1000 + ind4 * 100 + ind5 * 10 + ind6;
+                ind = ind * 100000 + ind2 * 10000 + ind3 * 1000 + ind4 * 100 + ind5 * 10 + ind6;
+                return negative ? -ind : ind;
             }
             int ind8 = IterImplNumber.intDigits[iter.buf[++i]];
             if (ind8 == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
                 iter.head = i;
-                return ind * 1000000 + ind2 * 100000 + ind3 * 10000 + ind4 * 1000 + ind5 * 100 + ind6 * 10 + ind7;
+                ind = ind * 1000000 + ind2 * 100000 + ind3 * 10000 + ind4 * 1000 + ind5 * 100 + ind6 * 10 + ind7;
+                return negative ? -ind : ind;
             }
             int ind9 = IterImplNumber.intDigits[iter.buf[++i]];
             ind = ind * 10000000 + ind2 * 1000000 + ind3 * 100000 + ind4 * 10000 + ind5 * 1000 + ind6 * 100 + ind7 * 10 + ind8;
             iter.head = i;
             if (ind9 == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
-                return ind;
+                return negative ? -ind : ind;
             }
         }
-        return IterImplForStreaming.readIntSlowPath(iter, ind);
+        return IterImplForStreaming.readIntSlowPath(iter, ind, negative);
     }
 
-    static final long readPositiveLong(final JsonIterator iter, byte c) throws IOException {
+    static final long readLong(final JsonIterator iter, final byte c, final boolean negative) throws IOException {
         long ind = IterImplNumber.intDigits[c];
         if (ind == 0) {
             IterImplForStreaming.assertNotLeadingZero(iter);
             return 0;
         }
         if (ind == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
-            throw iter.reportError("readPositiveLong", "expect 0~9");
+            throw iter.reportError("readLong", "expect 0~9");
         }
         if (iter.tail - iter.head > 9) {
             int i = iter.head;
             int ind2 = IterImplNumber.intDigits[iter.buf[i]];
             if (ind2 == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
                 iter.head = i;
-                return ind;
+                return negative ? -ind : ind;
             }
             int ind3 = IterImplNumber.intDigits[iter.buf[++i]];
             if (ind3 == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
                 iter.head = i;
-                return ind * 10 + ind2;
+                ind = ind * 10 + ind2;
+                return negative ? -ind : ind;
             }
             int ind4 = IterImplNumber.intDigits[iter.buf[++i]];
             if (ind4 == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
                 iter.head = i;
-                return ind * 100 + ind2 * 10 + ind3;
+                ind = ind * 100 + ind2 * 10 + ind3;
+                return negative ? -ind : ind;
             }
             int ind5 = IterImplNumber.intDigits[iter.buf[++i]];
             if (ind5 == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
                 iter.head = i;
-                return ind * 1000 + ind2 * 100 + ind3 * 10 + ind4;
+                ind = ind * 1000 + ind2 * 100 + ind3 * 10 + ind4;
+                return negative ? -ind : ind;
             }
             int ind6 = IterImplNumber.intDigits[iter.buf[++i]];
             if (ind6 == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
                 iter.head = i;
-                return ind * 10000 + ind2 * 1000 + ind3 * 100 + ind4 * 10 + ind5;
+                ind = ind * 10000 + ind2 * 1000 + ind3 * 100 + ind4 * 10 + ind5;
+                return negative ? -ind : ind;
             }
             int ind7 = IterImplNumber.intDigits[iter.buf[++i]];
             if (ind7 == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
                 iter.head = i;
-                return ind * 100000 + ind2 * 10000 + ind3 * 1000 + ind4 * 100 + ind5 * 10 + ind6;
+                ind = ind * 100000 + ind2 * 10000 + ind3 * 1000 + ind4 * 100 + ind5 * 10 + ind6;
+                return negative ? -ind : ind;
             }
             int ind8 = IterImplNumber.intDigits[iter.buf[++i]];
             if (ind8 == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
                 iter.head = i;
-                return ind * 1000000 + ind2 * 100000 + ind3 * 10000 + ind4 * 1000 + ind5 * 100 + ind6 * 10 + ind7;
+                ind = ind * 1000000 + ind2 * 100000 + ind3 * 10000 + ind4 * 1000 + ind5 * 100 + ind6 * 10 + ind7;
+                return negative ? -ind : ind;
             }
             int ind9 = IterImplNumber.intDigits[iter.buf[++i]];
             ind = ind * 10000000 + ind2 * 1000000 + ind3 * 100000 + ind4 * 10000 + ind5 * 1000 + ind6 * 100 + ind7 * 10 + ind8;
             iter.head = i;
             if (ind9 == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
-                return ind;
+                return negative ? -ind : ind;
             }
         }
-        return IterImplForStreaming.readLongSlowPath(iter, ind);
+        return IterImplForStreaming.readLongSlowPath(iter, ind, negative);
     }
 
-    static final double readPositiveDouble(final JsonIterator iter) throws IOException {
+    static final double readDouble(final JsonIterator iter, final boolean negative) throws IOException {
         int oldHead = iter.head;
         try {
             try {
-                long value = IterImplNumber.readLong(iter); // without the dot
+                long value = IterImplNumber.readLong(iter); // without the dot & sign
+                value = negative ? -value : value;
                 if (iter.head == iter.tail) {
                     return value;
                 }
@@ -448,14 +461,14 @@ class IterImpl {
                     iter.head++;
                     int start = iter.head;
                     c = iter.buf[iter.head++];
-                    long decimalPart = readPositiveLong(iter, c);
+                    long decimalPart = readLong(iter, c, negative);
                     int decimalPlaces = iter.head - start;
                     if (decimalPlaces > 0 && decimalPlaces < IterImplNumber.POW10.length && (iter.head - oldHead) < 10) {
-                        value = value * IterImplNumber.POW10[decimalPlaces] + decimalPart;
-                        return value / (double) IterImplNumber.POW10[decimalPlaces];
+                        return value + (decimalPart / (double) IterImplNumber.POW10[decimalPlaces]);
                     } else {
                         iter.head = oldHead;
-                        return IterImplForStreaming.readDoubleSlowPath(iter);
+                        double result = IterImplForStreaming.readDoubleSlowPath(iter);
+                        return negative ? -result : result;
                     }
                 } else {
                     return value;
@@ -463,12 +476,14 @@ class IterImpl {
             } finally {
                 if (iter.head < iter.tail && (iter.buf[iter.head] == 'e' || iter.buf[iter.head] == 'E')) {
                     iter.head = oldHead;
-                    return IterImplForStreaming.readDoubleSlowPath(iter);
+                    double result = IterImplForStreaming.readDoubleSlowPath(iter);
+                    return negative ? -result : result;
                 }
             }
         } catch (JsonException e) {
             iter.head = oldHead;
-            return IterImplForStreaming.readDoubleSlowPath(iter);
+            double result = IterImplForStreaming.readDoubleSlowPath(iter);
+            return negative ? -result : result;
         }
     }
 }

--- a/src/main/java/com/jsoniter/IterImplForStreaming.java
+++ b/src/main/java/com/jsoniter/IterImplForStreaming.java
@@ -499,7 +499,7 @@ class IterImplForStreaming {
                     return negative ? value : -value;
                 }
                 if (value < multmin) {
-                    throw iter.reportError("readIntSlowPath", "value is too large for int");
+                    throw iter.reportError("readLongSlowPath", "value is too large for int");
                 }
                 value = (value << 3) + (value << 1);
                 if (value < limit + ind) {

--- a/src/main/java/com/jsoniter/IterImplForStreaming.java
+++ b/src/main/java/com/jsoniter/IterImplForStreaming.java
@@ -499,7 +499,7 @@ class IterImplForStreaming {
                     return negative ? value : -value;
                 }
                 if (value < multmin) {
-                    throw iter.reportError("readLongSlowPath", "value is too large for int");
+                    throw iter.reportError("readLongSlowPath", "value is too large for long");
                 }
                 value = (value << 3) + (value << 1);
                 if (value < limit + ind) {

--- a/src/main/java/com/jsoniter/IterImplNumber.java
+++ b/src/main/java/com/jsoniter/IterImplNumber.java
@@ -62,8 +62,7 @@ class IterImplNumber {
     }
 
     public static final double readDouble(final JsonIterator iter) throws IOException {
-        final byte c = IterImpl.nextToken(iter);
-        boolean negative = c == '-';
+        boolean negative = IterImpl.nextToken(iter) == '-';
         if (!negative) {
             iter.unreadByte();
         }

--- a/src/main/java/com/jsoniter/IterImplNumber.java
+++ b/src/main/java/com/jsoniter/IterImplNumber.java
@@ -31,8 +31,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.jsoniter;
 
-import com.jsoniter.spi.JsonException;
-
 import java.io.IOException;
 
 class IterImplNumber {
@@ -65,40 +63,26 @@ class IterImplNumber {
 
     public static final double readDouble(final JsonIterator iter) throws IOException {
         final byte c = IterImpl.nextToken(iter);
-        if (c == '-') {
-            return -IterImpl.readPositiveDouble(iter);
-        } else {
+        boolean negative = c == '-';
+        if (!negative) {
             iter.unreadByte();
-            return IterImpl.readPositiveDouble(iter);
         }
+        return IterImpl.readDouble(iter, negative);
     }
 
     public static final float readFloat(final JsonIterator iter) throws IOException {
-        final byte c = IterImpl.nextToken(iter);
-        if (c == '-') {
-            return (float)-IterImpl.readPositiveDouble(iter);
-        } else {
-            iter.unreadByte();
-            return (float) IterImpl.readPositiveDouble(iter);
-        }
+        return (float) IterImplNumber.readDouble(iter);
     }
 
     public static final int readInt(final JsonIterator iter) throws IOException {
         byte c = IterImpl.nextToken(iter);
-        if (c == '-') {
-            return -IterImpl.readPositiveInt(iter, IterImpl.readByte(iter));
-        } else {
-            return IterImpl.readPositiveInt(iter, c);
-        }
+        boolean negative = c == '-';
+        return IterImpl.readInt(iter, negative ? IterImpl.readByte(iter) : c, negative);
     }
 
     public static final long readLong(JsonIterator iter) throws IOException {
         byte c = IterImpl.nextToken(iter);
-        if (c == '-') {
-            return -IterImpl.readPositiveLong(iter, IterImpl.readByte(iter));
-        } else {
-            return IterImpl.readPositiveLong(iter, c);
-        }
+        boolean negative = c == '-';
+        return IterImpl.readLong(iter, negative ? IterImpl.readByte(iter) : c, negative);
     }
-
 }

--- a/src/test/java/com/jsoniter/TestFloat.java
+++ b/src/test/java/com/jsoniter/TestFloat.java
@@ -34,10 +34,15 @@ public class TestFloat extends TestCase {
     public void test_decimal_places() throws IOException {
         assertEquals(Long.MAX_VALUE, parseFloat("9223372036854775807,"), 0.01f);
         assertEquals(Long.MAX_VALUE, parseDouble("9223372036854775807,"), 0.01f);
+        assertEquals(Long.MIN_VALUE, parseDouble("-9223372036854775808,"), 0.01f);
         assertEquals(9923372036854775807f, parseFloat("9923372036854775807,"), 0.01f);
+        assertEquals(-9923372036854775808f, parseFloat("-9923372036854775808,"), 0.01f);
         assertEquals(9923372036854775807d, parseDouble("9923372036854775807,"), 0.01f);
+        assertEquals(-9923372036854775808d, parseDouble("-9923372036854775808,"), 0.01f);
         assertEquals(720368.54775807f, parseFloat("720368.54775807,"), 0.01f);
+        assertEquals(-720368.54775807f, parseFloat("-720368.54775807,"), 0.01f);
         assertEquals(720368.54775807d, parseDouble("720368.54775807,"), 0.01f);
+        assertEquals(-720368.54775807d, parseDouble("-720368.54775807,"), 0.01f);
         assertEquals(72036.854775807f, parseFloat("72036.854775807,"), 0.01f);
         assertEquals(72036.854775807d, parseDouble("72036.854775807,"), 0.01f);
         assertEquals(720368.54775807f, parseFloat("720368.547758075,"), 0.01f);

--- a/src/test/java/com/jsoniter/TestInteger.java
+++ b/src/test/java/com/jsoniter/TestInteger.java
@@ -64,14 +64,38 @@ public class TestInteger extends TestCase {
 
     public void test_large_number() throws IOException {
         try {
-            JsonIterator.deserialize(Integer.toString(Integer.MIN_VALUE) + "1", Integer.class);
+            JsonIterator.deserialize("2147483648", Integer.class);
             fail();
         } catch (JsonException e) {
         }
+        for (int i = 300000000; i < 2000000000; i += 10000000) {
+            try {
+                JsonIterator.deserialize(i + "0", Integer.class);
+                fail();
+            } catch (JsonException e) {
+            }
+            try {
+                JsonIterator.deserialize(-i + "0", Integer.class);
+                fail();
+            } catch (JsonException e) {
+            }
+        }
         try {
-            JsonIterator.deserialize(Long.toString(Long.MAX_VALUE) + "1", Long.class);
+            JsonIterator.deserialize("9223372036854775808", Long.class);
             fail();
         } catch (JsonException e) {
+        }
+        for (long i = 1000000000000000000L; i < 9000000000000000000L; i += 100000000000000000L) {
+            try {
+                JsonIterator.deserialize(i + "0", Long.class);
+                fail();
+            } catch (JsonException e) {
+            }
+            try {
+                JsonIterator.deserialize(-i + "0", Long.class);
+                fail();
+            } catch (JsonException e) {
+            }
         }
     }
 


### PR DESCRIPTION
Problem is that 40000000000000000000 (too big to be mapped to java.langLong number in JSON) is succesfully parsed to 3106511852580896768L using current implementation from develop.