### PR TITLE
Consume less memory

### DIFF
--- a/src/main/java/com/jsoniter/IterImpl.java
+++ b/src/main/java/com/jsoniter/IterImpl.java
@@ -5,14 +5,8 @@ import com.jsoniter.spi.JsonException;
 import com.jsoniter.spi.Slice;
 
 import java.io.IOException;
-import java.math.BigInteger;
 
 class IterImpl {
-
-    private static BigInteger maxLong = BigInteger.valueOf(Long.MAX_VALUE);
-    private static BigInteger minLong = BigInteger.valueOf(Long.MIN_VALUE);
-    private static BigInteger maxInt = BigInteger.valueOf(Integer.MAX_VALUE);
-    private static BigInteger minInt = BigInteger.valueOf(Integer.MIN_VALUE);
 
     public static final int readObjectFieldAsHash(JsonIterator iter) throws IOException {
         if (readByte(iter) != '"') {

--- a/src/main/java/com/jsoniter/IterImplNumber.java
+++ b/src/main/java/com/jsoniter/IterImplNumber.java
@@ -35,8 +35,8 @@ import java.io.IOException;
 
 class IterImplNumber {
 
-    final static int[] intDigits = new int[127];
-    final static int[] floatDigits = new int[127];
+    final static byte[] intDigits = new byte[127];
+    final static byte[] floatDigits = new byte[127];
     final static int END_OF_NUMBER = -2;
     final static int DOT_IN_NUMBER = -3;
     final static int INVALID_CHAR_FOR_NUMBER = -1;
@@ -51,8 +51,8 @@ class IterImplNumber {
             intDigits[i] = INVALID_CHAR_FOR_NUMBER;
         }
         for (int i = '0'; i <= '9'; ++i) {
-            floatDigits[i] = (i - '0');
-            intDigits[i] = (i - '0');
+            floatDigits[i] = (byte) (i - '0');
+            intDigits[i] = (byte) (i - '0');
         }
         floatDigits[','] = END_OF_NUMBER;
         floatDigits[']'] = END_OF_NUMBER;

--- a/src/main/java/com/jsoniter/IterImplString.java
+++ b/src/main/java/com/jsoniter/IterImplString.java
@@ -35,22 +35,14 @@ import java.io.IOException;
 
 class IterImplString {
 
-    final static int[] hexDigits = new int['f' + 1];
-
-    static {
-        for (int i = 0; i < hexDigits.length; i++) {
-            hexDigits[i] = -1;
-        }
-        for (int i = '0'; i <= '9'; ++i) {
-            hexDigits[i] = (i - '0');
-        }
-        for (int i = 'a'; i <= 'f'; ++i) {
-            hexDigits[i] = ((i - 'a') + 10);
-        }
-        for (int i = 'A'; i <= 'F'; ++i) {
-            hexDigits[i] = ((i - 'A') + 10);
-        }
-    }
+    private final static byte[] hexDigits = {
+            /* 48 unused characters skipped */
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, // decimal digits
+            -1, -1, -1, -1, -1, -1, -1,
+            10, 11, 12, 13, 14, 15,       // hexadecimal digits, lowercase
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            10, 11, 12, 13, 14, 15        // hexadecimal digits, uppercase
+    };
 
     public static final String readString(JsonIterator iter) throws IOException {
         byte c = IterImpl.nextToken(iter);
@@ -95,10 +87,17 @@ class IterImplString {
     }
 
     public static int translateHex(final byte b) {
-        int val = hexDigits[b];
+        int val;
+        try {
+            val = hexDigits['0' + b];
+        } catch (ArrayIndexOutOfBoundsException e) {
+            throw new IndexOutOfBoundsException(b + " is not valid hex digit");
+        }
+
         if (val == -1) {
             throw new IndexOutOfBoundsException(b + " is not valid hex digit");
         }
+
         return val;
     }
 

--- a/src/main/java/com/jsoniter/JsonIterator.java
+++ b/src/main/java/com/jsoniter/JsonIterator.java
@@ -9,16 +9,12 @@ import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class JsonIterator implements Closeable {
 
     public Config configCache;
     private static boolean isStreamingEnabled = false;
-    final static ValueType[] valueTypes = new ValueType[256];
     InputStream in;
     byte[] buf;
     int head;
@@ -29,29 +25,6 @@ public class JsonIterator implements Closeable {
     final Slice reusableSlice = new Slice(null, 0, 0);
     char[] reusableChars = new char[32];
     Object existingObject = null; // the object should be bind to next
-
-    static {
-        for (int i = 0; i < valueTypes.length; i++) {
-            valueTypes[i] = ValueType.INVALID;
-        }
-        valueTypes['"'] = ValueType.STRING;
-        valueTypes['-'] = ValueType.NUMBER;
-        valueTypes['0'] = ValueType.NUMBER;
-        valueTypes['1'] = ValueType.NUMBER;
-        valueTypes['2'] = ValueType.NUMBER;
-        valueTypes['3'] = ValueType.NUMBER;
-        valueTypes['4'] = ValueType.NUMBER;
-        valueTypes['5'] = ValueType.NUMBER;
-        valueTypes['6'] = ValueType.NUMBER;
-        valueTypes['7'] = ValueType.NUMBER;
-        valueTypes['8'] = ValueType.NUMBER;
-        valueTypes['9'] = ValueType.NUMBER;
-        valueTypes['t'] = ValueType.BOOLEAN;
-        valueTypes['f'] = ValueType.BOOLEAN;
-        valueTypes['n'] = ValueType.NULL;
-        valueTypes['['] = ValueType.ARRAY;
-        valueTypes['{'] = ValueType.OBJECT;
-    }
 
     private JsonIterator(InputStream in, byte[] buf, int head, int tail) {
         this.in = in;
@@ -383,7 +356,7 @@ public class JsonIterator implements Closeable {
     }
 
     public ValueType whatIsNext() throws IOException {
-        ValueType valueType = valueTypes[IterImpl.nextToken(this)];
+        ValueType valueType = ValueType.ofCharacter(IterImpl.nextToken(this));
         unreadByte();
         return valueType;
     }

--- a/src/main/java/com/jsoniter/JsonIterator.java
+++ b/src/main/java/com/jsoniter/JsonIterator.java
@@ -263,23 +263,25 @@ public class JsonIterator implements Closeable {
         }
     }
 
-    private final static ReadArrayCallback fillArray = new ReadArrayCallback() {
+    private static final class ReadArrayObjectCallback implements ReadArrayCallback, ReadObjectCallback {
+
+        static final ReadArrayObjectCallback INSTANCE = new ReadArrayObjectCallback();
+
+        private ReadArrayObjectCallback() {}
+
         @Override
         public boolean handle(JsonIterator iter, Object attachment) throws IOException {
             List list = (List) attachment;
             list.add(iter.read());
             return true;
         }
-    };
-
-    private final static ReadObjectCallback fillObject = new ReadObjectCallback() {
         @Override
         public boolean handle(JsonIterator iter, String field, Object attachment) throws IOException {
             Map map = (Map) attachment;
             map.put(field, iter.read());
             return true;
         }
-    };
+    }
 
     public final Object read() throws IOException {
         try {
@@ -304,11 +306,11 @@ public class JsonIterator implements Closeable {
                     return readBoolean();
                 case ARRAY:
                     ArrayList list = new ArrayList(4);
-                    readArrayCB(fillArray, list);
+                    readArrayCB(ReadArrayObjectCallback.INSTANCE, list);
                     return list;
                 case OBJECT:
                     Map map = new HashMap(4);
-                    readObjectCB(fillObject, map);
+                    readObjectCB(ReadArrayObjectCallback.INSTANCE, map);
                     return map;
                 default:
                     throw reportError("read", "unexpected value type: " + valueType);

--- a/src/main/java/com/jsoniter/ValueType.java
+++ b/src/main/java/com/jsoniter/ValueType.java
@@ -7,5 +7,35 @@ public enum ValueType {
     NULL,
     BOOLEAN,
     ARRAY,
-    OBJECT
+    OBJECT;
+
+    private static final ValueType[] valueTypes = new ValueType[256];
+
+    static {
+        for (int i = 0; i < valueTypes.length; i++) {
+            valueTypes[i] = ValueType.INVALID;
+        }
+        valueTypes['"'] = ValueType.STRING;
+        valueTypes['-'] = ValueType.NUMBER;
+        valueTypes['0'] = ValueType.NUMBER;
+        valueTypes['1'] = ValueType.NUMBER;
+        valueTypes['2'] = ValueType.NUMBER;
+        valueTypes['3'] = ValueType.NUMBER;
+        valueTypes['4'] = ValueType.NUMBER;
+        valueTypes['5'] = ValueType.NUMBER;
+        valueTypes['6'] = ValueType.NUMBER;
+        valueTypes['7'] = ValueType.NUMBER;
+        valueTypes['8'] = ValueType.NUMBER;
+        valueTypes['9'] = ValueType.NUMBER;
+        valueTypes['t'] = ValueType.BOOLEAN;
+        valueTypes['f'] = ValueType.BOOLEAN;
+        valueTypes['n'] = ValueType.NULL;
+        valueTypes['['] = ValueType.ARRAY;
+        valueTypes['{'] = ValueType.OBJECT;
+    }
+
+    public static ValueType ofCharacter(byte character) {
+        return valueTypes[character];
+    }
+
 }


### PR DESCRIPTION
Reduced memory consumption:
— removed unused `BitInteger` constants in `IterImpl`;
— changed `IterImplNumber.intDigits`, `IterImplNumber.floatDigits` type from `int[]` to `byte[]`;
— changed `IterImplString.hexDigits` type from `int[]` to `byte[]` and shifted it by 48 (`'0'`);
— using `byte` constants instead of `ValueType` in `JsonIterator`, using own `byte[]` dictionary instead of `ValueType[]`.
