### PR TITLE
using Long.valueOf instead of casting double to long

### DIFF
--- a/src/main/java/com/jsoniter/JsonIterator.java
+++ b/src/main/java/com/jsoniter/JsonIterator.java
@@ -298,7 +298,7 @@ public class JsonIterator implements Closeable {
                     }
                     double doubleNumber = number;
                     if (doubleNumber == Math.floor(doubleNumber) && !Double.isInfinite(doubleNumber)) {
-                        long longNumber = (long) doubleNumber;
+                        long longNumber = Long.valueOf(new String(numberChars.chars, 0, numberChars.charsLength));
                         if (longNumber <= Integer.MAX_VALUE && longNumber >= Integer.MIN_VALUE) {
                             return (int) longNumber;
                         }

--- a/src/main/java/com/jsoniter/JsonIterator.java
+++ b/src/main/java/com/jsoniter/JsonIterator.java
@@ -292,13 +292,14 @@ public class JsonIterator implements Closeable {
                     return readString();
                 case NUMBER:
                     IterImplForStreaming.numberChars numberChars = IterImplForStreaming.readNumber(this);
-                    Double number = Double.valueOf(new String(numberChars.chars, 0, numberChars.charsLength));
+                    String numberStr = new String(numberChars.chars, 0, numberChars.charsLength);
+                    Double number = Double.valueOf(numberStr);
                     if (numberChars.dotFound) {
                         return number;
                     }
                     double doubleNumber = number;
                     if (doubleNumber == Math.floor(doubleNumber) && !Double.isInfinite(doubleNumber)) {
-                        long longNumber = Long.valueOf(new String(numberChars.chars, 0, numberChars.charsLength));
+                        long longNumber = Long.valueOf(numberStr);
                         if (longNumber <= Integer.MAX_VALUE && longNumber >= Integer.MIN_VALUE) {
                             return (int) longNumber;
                         }


### PR DESCRIPTION
When parsing some big number like 6643122506645376263, the result(6643122506645376000) will not be satisfying. 