### PR TITLE
Fixed leaky buffer when streaming.

### DIFF
--- a/src/main/java/com/jsoniter/IterImpl.java
+++ b/src/main/java/com/jsoniter/IterImpl.java
@@ -59,7 +59,7 @@ class IterImpl {
                 case '[': // If open symbol, increase level
                     level++;
                     break;
-                case ']': // If close symbol, increase level
+                case ']': // If close symbol, decrease level
                     level--;
 
                     // If we have returned to the original level, we're done
@@ -85,7 +85,7 @@ class IterImpl {
                 case '{': // If open symbol, increase level
                     level++;
                     break;
-                case '}': // If close symbol, increase level
+                case '}': // If close symbol, decrease level
                     level--;
 
                     // If we have returned to the original level, we're done

--- a/src/main/java/com/jsoniter/IterImplForStreaming.java
+++ b/src/main/java/com/jsoniter/IterImplForStreaming.java
@@ -71,7 +71,7 @@ class IterImplForStreaming {
                     case '[': // If open symbol, increase level
                         level++;
                         break;
-                    case ']': // If close symbol, increase level
+                    case ']': // If close symbol, decrease level
                         level--;
 
                         // If we have returned to the original level, we're done
@@ -101,7 +101,7 @@ class IterImplForStreaming {
                     case '{': // If open symbol, increase level
                         level++;
                         break;
-                    case '}': // If close symbol, increase level
+                    case '}': // If close symbol, decrease level
                         level--;
 
                         // If we have returned to the original level, we're done

--- a/src/main/java/com/jsoniter/IterImplForStreaming.java
+++ b/src/main/java/com/jsoniter/IterImplForStreaming.java
@@ -277,7 +277,7 @@ class IterImplForStreaming {
         int offset = iter.tail - iter.skipStartedAt;
         byte[] srcBuffer = iter.buf;
         // Check there is no unused buffer capacity
-        if (iter.buf.length - iter.tail == 0) {
+        if ((getUnusedBufferByteCount(iter)) == 0) {
           // If auto expand buffer enabled, then create larger buffer
           if (iter.autoExpandBufferStep > 0) {
             iter.buf = new byte[iter.buf.length + iter.autoExpandBufferStep];
@@ -299,6 +299,11 @@ class IterImplForStreaming {
             iter.tail = offset + n;
         }
         return true;
+    }
+
+    private static int getUnusedBufferByteCount(JsonIterator iter) {
+        // Get bytes from 0 to skipStart + from tail till end
+        return iter.buf.length - iter.tail + iter.skipStartedAt;
     }
 
     final static byte readByte(JsonIterator iter) throws IOException {

--- a/src/main/java/com/jsoniter/IterImplForStreaming.java
+++ b/src/main/java/com/jsoniter/IterImplForStreaming.java
@@ -147,7 +147,8 @@ class IterImplForStreaming {
                     throw iter.reportError("skipString", "incomplete string");
                 }
                 if (escaped) {
-                    iter.head = 1; // skip the first char as last char is \
+                    // TODO add unit test to prove/verify bug
+                    iter.head += 1; // skip the first char as last char is \
                 }
             } else {
                 iter.head = end;

--- a/src/main/java/com/jsoniter/IterImplForStreaming.java
+++ b/src/main/java/com/jsoniter/IterImplForStreaming.java
@@ -649,8 +649,7 @@ class IterImplForStreaming {
 
     static void assertNotLeadingZero(JsonIterator iter) throws IOException {
         try {
-            byte nextByte = IterImpl.readByte(iter);
-            iter.unreadByte();
+            byte nextByte = iter.buf[iter.head];
             int ind2 = IterImplNumber.intDigits[nextByte];
             if (ind2 == IterImplNumber.INVALID_CHAR_FOR_NUMBER) {
                 return;

--- a/src/main/java/com/jsoniter/IterImplForStreaming.java
+++ b/src/main/java/com/jsoniter/IterImplForStreaming.java
@@ -282,7 +282,7 @@ class IterImplForStreaming {
           if (iter.autoExpandBufferStep > 0) {
             iter.buf = new byte[iter.buf.length + iter.autoExpandBufferStep];
           } else {
-            throw iter.reportError("loadMore", "buffer is full and autoexpansion is disabled");
+            throw iter.reportError("loadMore", String.format("buffer is full and autoexpansion is disabled. tail: [%s] skipStartedAt: [%s]", iter.tail, iter.skipStartedAt));
           }
         }
         System.arraycopy(srcBuffer, iter.skipStartedAt, iter.buf, 0, offset);

--- a/src/main/java/com/jsoniter/JsonIterator.java
+++ b/src/main/java/com/jsoniter/JsonIterator.java
@@ -21,6 +21,9 @@ public class JsonIterator implements Closeable {
     final static ValueType[] valueTypes = new ValueType[256];
     InputStream in;
     byte[] buf;
+    // Whenever buf is not large enough new one is created with size of
+    // buf.length + autoExpandBufferStep. Set to < 1 to disable auto expanding.
+    int autoExpandBufferStep;
     int head;
     int tail;
     int skipStartedAt = -1; // skip should keep bytes starting at this pos
@@ -60,13 +63,22 @@ public class JsonIterator implements Closeable {
         this.tail = tail;
     }
 
+    private JsonIterator(InputStream in, byte[] buf, int autoExpandBufferStep) {
+        this(in, buf, 0, 0);
+        this.autoExpandBufferStep = autoExpandBufferStep;
+    }
+
     public JsonIterator() {
         this(null, new byte[0], 0, 0);
     }
 
     public static JsonIterator parse(InputStream in, int bufSize) {
+        return parse(in, bufSize, bufSize);
+    }
+
+    public static JsonIterator parse(InputStream in, int bufSize, int autoExpandBufferStep) {
         enableStreamingSupport();
-        return new JsonIterator(in, new byte[bufSize], 0, 0);
+        return new JsonIterator(in, new byte[bufSize], autoExpandBufferStep);
     }
 
     public static JsonIterator parse(byte[] buf) {

--- a/src/test/java/com/jsoniter/IterImplForStreamingTest.java
+++ b/src/test/java/com/jsoniter/IterImplForStreamingTest.java
@@ -1,6 +1,10 @@
 package com.jsoniter;
 
+import com.jsoniter.any.Any;
+import java.io.IOException;
+import java.io.InputStream;
 import junit.framework.TestCase;
+import org.junit.experimental.categories.Category;
 
 public class IterImplForStreamingTest extends TestCase {
 
@@ -10,5 +14,38 @@ public class IterImplForStreamingTest extends TestCase {
 		IterImplForStreaming.numberChars numberChars = IterImplForStreaming.readNumber(iter);
 		String number = new String(numberChars.chars, 0, numberChars.charsLength);
 		assertEquals(maxDouble, number);
+	}
+
+	@Category(StreamingCategory.class)
+	public void testLoadMore() throws IOException {
+		final String originalContent = "1234";
+		final byte[] src = ("{\"a\":\"" + originalContent + "\"}").getBytes();
+		InputStream slowStream = new InputStream() {
+			int position = 0;
+			boolean pretendEmptyNextRead = false;
+
+			@Override
+			public int read() throws IOException {
+				if (position < src.length) {
+					if (pretendEmptyNextRead) {
+						pretendEmptyNextRead = false;
+						return -1;
+					} else {
+						pretendEmptyNextRead = true;
+						return src[position++];
+					}
+				}
+				return -1;
+			}
+		};
+
+		// Input must definitely fit into such large buffer
+		final int initialBufferSize = src.length * 2;
+		JsonIterator jsonIterator = JsonIterator.parse(slowStream, initialBufferSize);
+		jsonIterator.readObject();
+		Any parsedString = jsonIterator.readAny();
+		assertEquals(originalContent, parsedString.toString());
+		// Check buffer was not expanded prematurely
+		assertEquals(initialBufferSize, jsonIterator.buf.length);
 	}
 }

--- a/src/test/java/com/jsoniter/IterImplForStreamingTest.java
+++ b/src/test/java/com/jsoniter/IterImplForStreamingTest.java
@@ -2,6 +2,7 @@ package com.jsoniter;
 
 import com.jsoniter.any.Any;
 import com.jsoniter.spi.JsonException;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import junit.framework.TestCase;
@@ -35,7 +36,7 @@ public class IterImplForStreamingTest extends TestCase {
 		// Check buffer was not expanded
 		assertEquals(initialBufferSize, jsonIterator.buf.length);
 
-		// Case #2: Data does fit into initial buffer, autoresizing off
+		// Case #2: Data does not fit into initial buffer, autoresizing off
 		initialBufferSize = originalContent.length() / 2;
 		jsonIterator = JsonIterator.parse(getSluggishInputStream(src), initialBufferSize, 0);
 		jsonIterator.readObject();
@@ -59,6 +60,15 @@ public class IterImplForStreamingTest extends TestCase {
 		assertEquals(originalContent, parsedString.toString());
 		// Check buffer was expanded exactly once
 		assertEquals(initialBufferSize + autoExpandBufferStep, jsonIterator.buf.length);
+
+		// Case #4: Data does not fit (but largest string does) into initial buffer, autoresizing on
+		initialBufferSize = originalContent.length() + 2;
+		jsonIterator = JsonIterator.parse(new ByteArrayInputStream(src), initialBufferSize, 0);
+		jsonIterator.readObject();
+		parsedString = jsonIterator.readAny();
+		assertEquals(originalContent, parsedString.toString());
+		// Check buffer was expanded exactly once
+		assertEquals(initialBufferSize, jsonIterator.buf.length);
 	}
 
 	private static InputStream getSluggishInputStream(final byte[] src) {

--- a/src/test/java/com/jsoniter/IterImplForStreamingTest.java
+++ b/src/test/java/com/jsoniter/IterImplForStreamingTest.java
@@ -1,10 +1,12 @@
 package com.jsoniter;
 
 import com.jsoniter.any.Any;
+import com.jsoniter.spi.JsonException;
 import java.io.IOException;
 import java.io.InputStream;
 import junit.framework.TestCase;
 import org.junit.experimental.categories.Category;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public class IterImplForStreamingTest extends TestCase {
 
@@ -18,34 +20,64 @@ public class IterImplForStreamingTest extends TestCase {
 
 	@Category(StreamingCategory.class)
 	public void testLoadMore() throws IOException {
-		final String originalContent = "1234";
+		final String originalContent = "1234567890";
 		final byte[] src = ("{\"a\":\"" + originalContent + "\"}").getBytes();
-		InputStream slowStream = new InputStream() {
+
+		int initialBufferSize;
+		Any parsedString;
+		// Case #1: Data fits into initial buffer, autoresizing on
+		// Input must definitely fit into such large buffer
+		initialBufferSize = src.length * 2;
+		JsonIterator jsonIterator = JsonIterator.parse(getSluggishInputStream(src), initialBufferSize, 512);
+		jsonIterator.readObject();
+		parsedString = jsonIterator.readAny();
+		assertEquals(originalContent, parsedString.toString());
+		// Check buffer was not expanded
+		assertEquals(initialBufferSize, jsonIterator.buf.length);
+
+		// Case #2: Data does fit into initial buffer, autoresizing off
+		initialBufferSize = originalContent.length() / 2;
+		jsonIterator = JsonIterator.parse(getSluggishInputStream(src), initialBufferSize, 0);
+		jsonIterator.readObject();
+		try {
+			jsonIterator.readAny();
+			fail("Expect to fail because buffer is too small.");
+		} catch (JsonException e) {
+			if (!e.getMessage().startsWith("loadMore")) {
+				throw e;
+			}
+		}
+		// Check buffer was not expanded
+		assertEquals(initialBufferSize, jsonIterator.buf.length);
+
+		// Case #3: Data does fit into initial buffer, autoresizing on
+		initialBufferSize = originalContent.length() / 2;
+		int autoExpandBufferStep = initialBufferSize * 3;
+		jsonIterator = JsonIterator.parse(getSluggishInputStream(src), initialBufferSize, autoExpandBufferStep);
+		jsonIterator.readObject();
+		parsedString = jsonIterator.readAny();
+		assertEquals(originalContent, parsedString.toString());
+		// Check buffer was expanded exactly once
+		assertEquals(initialBufferSize + autoExpandBufferStep, jsonIterator.buf.length);
+	}
+
+	private static InputStream getSluggishInputStream(final byte[] src) {
+		return new InputStream() {
 			int position = 0;
-			boolean pretendEmptyNextRead = false;
 
 			@Override
 			public int read() throws IOException {
+				throw new NotImplementedException();
+			}
+
+			@Override
+			public int read(byte[] b, int off, int len) throws IOException {
 				if (position < src.length) {
-					if (pretendEmptyNextRead) {
-						pretendEmptyNextRead = false;
-						return -1;
-					} else {
-						pretendEmptyNextRead = true;
-						return src[position++];
-					}
+					b[off] = src[position++];
+					return 1;
 				}
 				return -1;
 			}
 		};
-
-		// Input must definitely fit into such large buffer
-		final int initialBufferSize = src.length * 2;
-		JsonIterator jsonIterator = JsonIterator.parse(slowStream, initialBufferSize);
-		jsonIterator.readObject();
-		Any parsedString = jsonIterator.readAny();
-		assertEquals(originalContent, parsedString.toString());
-		// Check buffer was not expanded prematurely
-		assertEquals(initialBufferSize, jsonIterator.buf.length);
 	}
 }

--- a/src/test/java/com/jsoniter/any/TestLong.java
+++ b/src/test/java/com/jsoniter/any/TestLong.java
@@ -1,10 +1,28 @@
 package com.jsoniter.any;
 
+import com.jsoniter.spi.JsonException;
 import junit.framework.TestCase;
 
 public class TestLong extends TestCase {
     public void test_to_string_should_trim() {
         Any any = Any.lazyLong(" 1000".getBytes(), 0, " 1000".length());
         assertEquals("1000", any.toString());
+    }
+
+    public void test_should_fail_with_leading_zero() {
+        byte[] bytes = "01".getBytes();
+        Any any = Any.lazyLong(bytes, 0, bytes.length);
+        try {
+            any.toLong();
+            fail("This should fail.");
+        } catch (JsonException e) {
+
+        }
+    }
+
+    public void test_should_work_with_zero() {
+        byte[] bytes = "0".getBytes();
+        Any any = Any.lazyLong(bytes, 0, bytes.length);
+        assertEquals(0L, any.toLong());
     }
 }

--- a/src/test/java/com/jsoniter/suite/AllTestCases.java
+++ b/src/test/java/com/jsoniter/suite/AllTestCases.java
@@ -53,6 +53,7 @@ import org.junit.runners.Suite;
         TestGson.class,
         com.jsoniter.output.TestGson.class,
         TestStreamBuffer.class,
+        IterImplForStreamingTest.class,
         TestCollection.class,
         TestList.class,
         TestAnnotationJsonObject.class,


### PR DESCRIPTION
Reworked a way how internal buffer size increases when streaming. The new way changes both `when` and `how` it increases size. 

When: Whenever current buffer size is fully utilized AND autoresizing is enabled.
How: It increases buffer size with configured absolute number of bytes instead of doubling the capacity.

New API: Added new factory method `parse(InputStream in, int bufSize, int autoExpandBufferStep)` that creates Iterator with posibility to control how autoresizing works. Set 0 to disable, set 5 to increase buffer size of 5 bytes everytime we hit end.

Backward compatibility: Factory `parse(InputStream in, int bufSize)` was changed with respect to previous setting. First increase of buffer size is exactly same as it was in pass though any subsequent increase is same size as first one in contrast to previous behaviour (it was growing exponentially).