### PR TITLE
Adding encoding as parameter to methods deserialize and serialize

### DIFF
--- a/src/main/java/com/jsoniter/JsonIterator.java
+++ b/src/main/java/com/jsoniter/JsonIterator.java
@@ -6,9 +6,11 @@ import com.jsoniter.spi.*;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -492,6 +494,10 @@ public class JsonIterator implements Closeable {
 
     public static final Any deserialize(String input) {
         return deserialize(input.getBytes());
+    }
+
+    public static Any deserialize(final String input, final Charset charset) {
+        return deserialize(input.getBytes(charset));
     }
 
     public static final Any deserialize(Config config, byte[] input) {

--- a/src/main/java/com/jsoniter/output/JsonStream.java
+++ b/src/main/java/com/jsoniter/output/JsonStream.java
@@ -6,6 +6,8 @@ import com.jsoniter.spi.*;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 public class JsonStream extends OutputStream {
 
@@ -470,6 +472,10 @@ public class JsonStream extends OutputStream {
         return serialize(JsoniterSpi.getCurrentConfig().escapeUnicode(), obj.getClass(), obj);
     }
 
+    public static String serialize(Object obj, final Charset charset) {
+        return serialize(JsoniterSpi.getCurrentConfig().escapeUnicode(), obj.getClass(), obj, charset);
+    }
+
     public static String serialize(Config config, TypeLiteral typeLiteral, Object obj) {
         JsoniterSpi.setCurrentConfig(config);
         try {
@@ -484,12 +490,16 @@ public class JsonStream extends OutputStream {
     }
 
     public static String serialize(boolean escapeUnicode, Type type, Object obj) {
+        return  serialize(escapeUnicode, type, obj, Charset.defaultCharset());
+    }
+
+    public static String serialize(boolean escapeUnicode, Type type, Object obj, Charset charset) {
         JsonStream stream = JsonStreamPool.borrowJsonStream();
         try {
             stream.reset(null);
             stream.writeVal(type, obj);
             if (escapeUnicode) {
-                return new String(stream.buf, 0, stream.count);
+                return new String(stream.buf, 0, stream.count, charset);
             } else {
                 return new String(stream.buf, 0, stream.count, "UTF8");
             }
@@ -504,7 +514,6 @@ public class JsonStream extends OutputStream {
         Config newConfig = JsoniterSpi.getDefaultConfig().copyBuilder().encodingMode(mode).build();
         JsoniterSpi.setDefaultConfig(newConfig);
         JsoniterSpi.setCurrentConfig(newConfig);
-
     }
 
     public static void setIndentionStep(int indentionStep) {

--- a/src/test/java/com/jsoniter/output/TestString.java
+++ b/src/test/java/com/jsoniter/output/TestString.java
@@ -1,15 +1,45 @@
 package com.jsoniter.output;
 
+import com.jsoniter.JsonIterator;
+import com.jsoniter.any.Any;
 import com.jsoniter.spi.Config;
 import junit.framework.TestCase;
+
+import java.lang.reflect.Field;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 public class TestString extends TestCase {
     public void test_unicode() {
         String output = JsonStream.serialize(new Config.Builder().escapeUnicode(false).build(), "中文");
         assertEquals("\"中文\"", output);
     }
+
     public void test_escape_control_character() {
         String output = JsonStream.serialize(new String(new byte[]{0}));
         assertEquals("\"\\u0000\"", output);
+    }
+
+    public void test_encoding_different_than_default() throws NoSuchFieldException, IllegalAccessException {
+        Charset defaultEncoding = Charset.defaultCharset();
+        try {
+            // Sets the default encoding
+            setDefaultEncoding("US-ASCII");
+
+            Any output = JsonIterator.deserialize("{\"name\":\"Thomas Müller\"}", StandardCharsets.UTF_8);
+            assertEquals("{\"name\":\"Thomas Müller\"}", JsonStream.serialize(output, StandardCharsets.UTF_8));
+        } finally {
+            // Sets the default encoding  back to its real default
+            setDefaultEncoding(defaultEncoding.name());
+        }
+    }
+
+    private void setDefaultEncoding(String defaultEncoding) throws NoSuchFieldException, IllegalAccessException {
+        // This block sets the Default Charset
+        System.setProperty("file.encoding", defaultEncoding);
+        // Unfortunately this "hack" is necessary (https://stackoverflow.com/questions/361975/setting-the-default-java-character-encoding)
+        Field cs = Charset.class.getDeclaredField("defaultCharset");
+        cs.setAccessible(true);
+        cs.set(null, null);
     }
 }


### PR DESCRIPTION
This pull request tries to address the issue https://github.com/json-iterator/java/issues/229

Especially with so many managed services on the Cloud, some of which we do not have any control over the initialization of the JVM, it is important to be able to control the encoding used by the library. I faced recently the problem of having one of these managed services in US-ASCII, but our Strings were encoded with UTF-8. All special characters were transformed to "?".