### PR TITLE
Java 17, jigsaw modules, records

### DIFF
--- a/DependencyUpdateSearch_Rules.xml
+++ b/DependencyUpdateSearch_Rules.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" comparisonMethod="maven" xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+    <ignoreVersions>
+        <!-- Ignore Alpha's, Beta's, release candidates and milestones -->
+        <ignoreVersion type="regex">(?i).*Alpha(?:-?\d+)?</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*a(?:-?\d+)?</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*Beta(?:-?\d+)?</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*-B(?:-?\d+)?</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*RC(?:-?\d+)?</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*CR(?:-?\d+)?</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*M(?:-?\d+)?</ignoreVersion>
+    </ignoreVersions>
+    <rules>
+    </rules>
+</ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,12 @@
             <version>1.20</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -121,8 +127,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <release>16</release>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
@@ -150,7 +155,7 @@
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <doclint>none</doclint>
                         </configuration>
                     </execution>
                 </executions>
@@ -196,6 +201,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.21.0</version>
                 <configuration>
+                    <testFailureIgnore>true</testFailureIgnore>
                     <parallel>methods</parallel>
                     <threadCount>1</threadCount>
                     <reuseForks>false</reuseForks>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -52,38 +52,38 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.5</version>
+            <version>2.13.3</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.5</version>
+            <version>2.13.3</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.3</version>
+            <version>2.9.1</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
-            <version>1.20</version>
+            <version>1.35</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
-            <version>1.20</version>
+            <version>1.35</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.5</version>
+            <version>3.12.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -125,16 +125,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.10.1</version>
                 <configuration>
-                    <release>16</release>
+                    <release>17</release>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -147,7 +147,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -177,7 +177,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
+                <version>1.6.13</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -199,7 +199,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.21.0</version>
+                <version>2.20</version> <!-- note: 2.20.1 to 2.22.2 crash during tests -->
                 <configuration>
                     <testFailureIgnore>true</testFailureIgnore>
                     <parallel>methods</parallel>
@@ -215,6 +215,46 @@
                     </includes>
                 </configuration>
             </plugin>
+        
+	        <plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>versions-maven-plugin</artifactId>
+				<version>2.11.0</version>
+				<configuration>
+					<rulesUri>file:///${project.basedir}/DependencyUpdateSearch_Rules.xml</rulesUri>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>verify</phase>
+						<goals>
+							<goal>display-dependency-updates</goal>
+							<goal>display-plugin-updates</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.1.0</version>
+				<executions>
+					<execution>
+						<id>enforce-maven</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>[3.3.2,)</version>
+								</requireMavenVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,8 @@
                 <version>3.10.1</version>
                 <configuration>
                     <release>17</release>
+                    <source>17</source>
+					<target>17</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/src/main/java/com/jsoniter/ReflectionDecoderFactory.java
+++ b/src/main/java/com/jsoniter/ReflectionDecoderFactory.java
@@ -24,7 +24,7 @@ class ReflectionDecoderFactory {
             return new ReflectionEnumDecoder(clazz);
         }
         if (clazz.isRecord()) {
-            return new ReflectionRecordDecoder(clazz, typeArgs);
+            return new ReflectionRecordDecoder(classAndArgs).create();
         }
         return new ReflectionObjectDecoder(classAndArgs).create();
     }

--- a/src/main/java/com/jsoniter/ReflectionDecoderFactory.java
+++ b/src/main/java/com/jsoniter/ReflectionDecoderFactory.java
@@ -23,6 +23,9 @@ class ReflectionDecoderFactory {
         if (clazz.isEnum()) {
             return new ReflectionEnumDecoder(clazz);
         }
+        if (clazz.isRecord()) {
+            return new ReflectionRecordDecoder(clazz, typeArgs);
+        }
         return new ReflectionObjectDecoder(classAndArgs).create();
     }
 }

--- a/src/main/java/com/jsoniter/ReflectionObjectDecoder.java
+++ b/src/main/java/com/jsoniter/ReflectionObjectDecoder.java
@@ -9,20 +9,20 @@ import java.util.*;
 
 class ReflectionObjectDecoder {
 
-    private static Object NOT_SET = new Object() {
+    protected static Object NOT_SET = new Object() {
         @Override
         public String toString() {
             return "NOT_SET";
         }
     };
-    private Map<Slice, Binding> allBindings = new HashMap<Slice, Binding>();
-    private String tempCacheKey;
-    private String ctorArgsCacheKey;
-    private int tempCount;
-    private long expectedTracker;
-    private int requiredIdx;
-    private int tempIdx;
-    private ClassDescriptor desc;
+    protected Map<Slice, Binding> allBindings = new HashMap<Slice, Binding>();
+    protected String tempCacheKey;
+    protected String ctorArgsCacheKey;
+    protected int tempCount;
+    protected long expectedTracker;
+    protected int requiredIdx;
+    protected int tempIdx;
+    protected ClassDescriptor desc;
 
     public ReflectionObjectDecoder(ClassInfo classInfo) {
         try {
@@ -34,7 +34,9 @@ class ReflectionObjectDecoder {
         }
     }
 
-    private final void init(ClassInfo classInfo) throws Exception {
+    protected final void init(ClassInfo classInfo) throws Exception {
+
+        System.out.println("INIT");
         Class clazz = classInfo.clazz;
         ClassDescriptor desc = ClassDescriptor.getDecodingClassDescriptor(classInfo, true);
         for (Binding param : desc.ctor.parameters) {
@@ -116,6 +118,7 @@ class ReflectionObjectDecoder {
 
         public Object decode(JsonIterator iter) throws IOException {
             try {
+                System.out.println("ONLY FIELD");
                 return decode_(iter);
             } catch (RuntimeException e) {
                 throw e;
@@ -181,6 +184,7 @@ class ReflectionObjectDecoder {
         @Override
         public Object decode(JsonIterator iter) throws IOException {
             try {
+                System.out.println("WITH CTOR");
                 return decode_(iter);
             } catch (RuntimeException e) {
                 throw e;
@@ -260,6 +264,7 @@ class ReflectionObjectDecoder {
         @Override
         public Object decode(JsonIterator iter) throws IOException {
             try {
+                System.out.println("WITH WRAPPER");
                 return decode_(iter);
             } catch (RuntimeException e) {
                 throw e;
@@ -346,7 +351,7 @@ class ReflectionObjectDecoder {
         }
     }
 
-    private void setExtra(Object obj, Map<String, Object> extra) throws Exception {
+    protected void setExtra(Object obj, Map<String, Object> extra) throws Exception {
         if (extra == null) {
             return;
         }
@@ -367,24 +372,24 @@ class ReflectionObjectDecoder {
         }
     }
 
-    private boolean canNotSetDirectly(Binding binding) {
+    protected boolean canNotSetDirectly(Binding binding) {
         return binding.field == null && binding.method == null;
     }
 
-    private Object decodeBinding(JsonIterator iter, Binding binding) throws Exception {
+    protected Object decodeBinding(JsonIterator iter, Binding binding) throws Exception {
         Object value;
         value = binding.decoder.decode(iter);
         return value;
     }
 
-    private Object decodeBinding(JsonIterator iter, Object obj, Binding binding) throws Exception {
+    protected Object decodeBinding(JsonIterator iter, Object obj, Binding binding) throws Exception {
         if (binding.valueCanReuse) {
             CodegenAccess.setExistingObject(iter, binding.field.get(obj));
         }
         return decodeBinding(iter, binding);
     }
 
-    private Map<String, Object> onUnknownProperty(JsonIterator iter, Slice fieldName, Map<String, Object> extra) throws IOException {
+    protected Map<String, Object> onUnknownProperty(JsonIterator iter, Slice fieldName, Map<String, Object> extra) throws IOException {
         boolean shouldReadValue = desc.asExtraForUnknownProperties || !desc.keyValueTypeWrappers.isEmpty();
         if (shouldReadValue) {
             Any value = iter.readAny();
@@ -398,7 +403,7 @@ class ReflectionObjectDecoder {
         return extra;
     }
 
-    private List<String> collectMissingFields(long tracker) {
+    protected List<String> collectMissingFields(long tracker) {
         List<String> missingFields = new ArrayList<String>();
         for (Binding binding : allBindings.values()) {
             if (binding.asMissingWhenNotPresent) {
@@ -409,7 +414,7 @@ class ReflectionObjectDecoder {
         return missingFields;
     }
 
-    private void applyWrappers(Object[] temp, Object obj) throws Exception {
+    protected void applyWrappers(Object[] temp, Object obj) throws Exception {
         for (WrapperDescriptor wrapper : desc.bindingTypeWrappers) {
             Object[] args = new Object[wrapper.parameters.size()];
             for (int i = 0; i < wrapper.parameters.size(); i++) {
@@ -422,7 +427,7 @@ class ReflectionObjectDecoder {
         }
     }
 
-    private Object createNewObject(JsonIterator iter, Object[] temp) throws Exception {
+    protected Object createNewObject(JsonIterator iter, Object[] temp) throws Exception {
         if (iter.tempObjects == null) {
             iter.tempObjects = new HashMap<String, Object>();
         }

--- a/src/main/java/com/jsoniter/ReflectionObjectDecoder.java
+++ b/src/main/java/com/jsoniter/ReflectionObjectDecoder.java
@@ -36,7 +36,6 @@ class ReflectionObjectDecoder {
 
     protected final void init(ClassInfo classInfo) throws Exception {
 
-        System.out.println("INIT");
         Class clazz = classInfo.clazz;
         ClassDescriptor desc = ClassDescriptor.getDecodingClassDescriptor(classInfo, true);
         for (Binding param : desc.ctor.parameters) {
@@ -118,7 +117,6 @@ class ReflectionObjectDecoder {
 
         public Object decode(JsonIterator iter) throws IOException {
             try {
-                System.out.println("ONLY FIELD");
                 return decode_(iter);
             } catch (RuntimeException e) {
                 throw e;
@@ -184,7 +182,6 @@ class ReflectionObjectDecoder {
         @Override
         public Object decode(JsonIterator iter) throws IOException {
             try {
-                System.out.println("WITH CTOR");
                 return decode_(iter);
             } catch (RuntimeException e) {
                 throw e;
@@ -264,7 +261,6 @@ class ReflectionObjectDecoder {
         @Override
         public Object decode(JsonIterator iter) throws IOException {
             try {
-                System.out.println("WITH WRAPPER");
                 return decode_(iter);
             } catch (RuntimeException e) {
                 throw e;

--- a/src/main/java/com/jsoniter/ReflectionRecordDecoder.java
+++ b/src/main/java/com/jsoniter/ReflectionRecordDecoder.java
@@ -1,0 +1,114 @@
+package com.jsoniter;
+
+import com.jsoniter.spi.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ReflectionRecordDecoder extends ReflectionObjectDecoder {
+
+    private boolean useOnlyFieldRecord = false;
+
+    public ReflectionRecordDecoder(ClassInfo classInfo) {
+
+        super(classInfo);
+
+        if (desc.clazz.isRecord() && !desc.fields.isEmpty() && tempCount == 0) {
+            tempCount = tempIdx;
+            tempCacheKey = "temp@" + desc.clazz.getName();
+            ctorArgsCacheKey = "ctor@" + desc.clazz.getName();
+
+            desc.ctor.parameters.addAll(desc.fields);
+            useOnlyFieldRecord = true;
+        }
+    }
+
+    @Override
+    public Decoder create() {
+
+        if (useOnlyFieldRecord)
+            return new OnlyFieldRecord();
+
+        if (desc.ctor.parameters.isEmpty()) {
+            if (desc.bindingTypeWrappers.isEmpty()) {
+                return new OnlyFieldRecord();
+            } else {
+                return new WithWrapper();
+            }
+        } else {
+            return new WithCtor();
+        }
+    }
+
+    public class OnlyFieldRecord implements Decoder {
+
+        @Override
+        public Object decode(JsonIterator iter) throws IOException {
+
+            try {
+                System.out.println("ONLY FIELD RECORD");
+                return decode_(iter);
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new JsonException(e);
+            }
+        }
+
+        private Object decode_(JsonIterator iter) throws Exception {
+            if (iter.readNull()) {
+                CodegenAccess.resetExistingObject(iter);
+                return null;
+            }
+            if (iter.tempObjects == null) {
+                iter.tempObjects = new HashMap<String, Object>();
+            }
+            Object[] temp = (Object[]) iter.tempObjects.get(tempCacheKey);
+            if (temp == null) {
+                temp = new Object[tempCount];
+                iter.tempObjects.put(tempCacheKey, temp);
+            }
+            Arrays.fill(temp, NOT_SET);
+            if (!CodegenAccess.readObjectStart(iter)) {
+                if (requiredIdx > 0) {
+                    throw new JsonException("missing required properties: " + collectMissingFields(0));
+                }
+                return createNewObject(iter, temp);
+            }
+            Map<String, Object> extra = null;
+            long tracker = 0L;
+            Slice fieldName = CodegenAccess.readObjectFieldAsSlice(iter);
+            Binding binding = allBindings.get(fieldName);
+            if (binding == null) {
+                extra = onUnknownProperty(iter, fieldName, extra);
+            } else {
+                if (binding.asMissingWhenNotPresent) {
+                    tracker |= binding.mask;
+                }
+                temp[binding.idx] = decodeBinding(iter, binding);
+            }
+            while (CodegenAccess.nextToken(iter) == ',') {
+                fieldName = CodegenAccess.readObjectFieldAsSlice(iter);
+                binding = allBindings.get(fieldName);
+                if (binding == null) {
+                    extra = onUnknownProperty(iter, fieldName, extra);
+                } else {
+                    if (binding.asMissingWhenNotPresent) {
+                        tracker |= binding.mask;
+                    }
+                    temp[binding.idx] = decodeBinding(iter, binding);
+                }
+            }
+            if (tracker != expectedTracker) {
+                throw new JsonException("missing required properties: " + collectMissingFields(tracker));
+            }
+            Object obj = createNewObject(iter, temp.clone());
+            setExtra(obj, extra);
+            applyWrappers(temp, obj);
+            return obj;
+        }
+
+    }
+}

--- a/src/main/java/com/jsoniter/ReflectionRecordDecoder.java
+++ b/src/main/java/com/jsoniter/ReflectionRecordDecoder.java
@@ -48,7 +48,6 @@ public class ReflectionRecordDecoder extends ReflectionObjectDecoder {
         public Object decode(JsonIterator iter) throws IOException {
 
             try {
-                System.out.println("ONLY FIELD RECORD");
                 return decode_(iter);
             } catch (RuntimeException e) {
                 throw e;

--- a/src/main/java/com/jsoniter/spi/ClassDescriptor.java
+++ b/src/main/java/com/jsoniter/spi/ClassDescriptor.java
@@ -203,14 +203,13 @@ public class ClassDescriptor {
         return cctor;
     }
 
-    private static ConstructorDescriptor getRecordCtor(Class clazz) {
+    private static ConstructorDescriptor getRecordCtor(Class<?> clazz) {
         ConstructorDescriptor cctor = new ConstructorDescriptor();
         try {
-            Constructor<?> ctor = clazz.getDeclaredConstructors()[0];
-            cctor.ctor = ctor;
-            for (Type parameter : ctor.getParameterTypes()) {
-                ClassInfo info = new ClassInfo(parameter);
-            }
+            Class<?>[] canonicalParameterTypes = Arrays.stream(clazz.getRecordComponents()).map(RecordComponent::getType).toArray(Class<?>[]::new);
+            System.out.println("Canonical Parameter Types : ");
+            System.out.println(Arrays.toString(canonicalParameterTypes));
+            cctor.ctor = clazz.getDeclaredConstructor(canonicalParameterTypes);
         } catch (Exception e) {
             cctor.ctor = null;
         }

--- a/src/main/java/com/jsoniter/spi/ClassDescriptor.java
+++ b/src/main/java/com/jsoniter/spi/ClassDescriptor.java
@@ -207,8 +207,6 @@ public class ClassDescriptor {
         ConstructorDescriptor cctor = new ConstructorDescriptor();
         try {
             Class<?>[] canonicalParameterTypes = Arrays.stream(clazz.getRecordComponents()).map(RecordComponent::getType).toArray(Class<?>[]::new);
-            System.out.println("Canonical Parameter Types : ");
-            System.out.println(Arrays.toString(canonicalParameterTypes));
             cctor.ctor = clazz.getDeclaredConstructor(canonicalParameterTypes);
         } catch (Exception e) {
             cctor.ctor = null;

--- a/src/main/java/com/jsoniter/spi/ClassDescriptor.java
+++ b/src/main/java/com/jsoniter/spi/ClassDescriptor.java
@@ -31,7 +31,7 @@ public class ClassDescriptor {
         desc.classInfo = classInfo;
         desc.clazz = clazz;
         desc.lookup = lookup;
-        desc.ctor = getCtor(clazz);
+        desc.ctor = clazz.isRecord() ? getRecordCtor(clazz) : getCtor(clazz);
         desc.setters = getSetters(lookup, classInfo, includingPrivate);
         desc.getters = new ArrayList<Binding>();
         desc.fields = getFields(lookup, classInfo, includingPrivate);
@@ -197,6 +197,20 @@ public class ClassDescriptor {
         }
         try {
             cctor.ctor = clazz.getDeclaredConstructor();
+        } catch (Exception e) {
+            cctor.ctor = null;
+        }
+        return cctor;
+    }
+
+    private static ConstructorDescriptor getRecordCtor(Class clazz) {
+        ConstructorDescriptor cctor = new ConstructorDescriptor();
+        try {
+            Constructor<?> ctor = clazz.getDeclaredConstructors()[0];
+            cctor.ctor = ctor;
+            for (Type parameter : ctor.getParameterTypes()) {
+                ClassInfo info = new ClassInfo(parameter);
+            }
         } catch (Exception e) {
             cctor.ctor = null;
         }
@@ -431,7 +445,6 @@ public class ClassDescriptor {
         }
         return bindings;
     }
-
 
     public List<Binding> allEncoderBindings() {
         ArrayList<Binding> bindings = new ArrayList<Binding>(8);

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,29 @@
+open module com.jsoniter {
+	exports com.jsoniter.fuzzy;
+
+	exports com.jsoniter.static_codegen;
+
+	exports com.jsoniter.extra;
+
+	exports com.jsoniter.output;
+
+	exports com.jsoniter.annotation;
+
+	exports com.jsoniter;
+
+	exports com.jsoniter.spi;
+
+	exports com.jsoniter.any;
+
+	requires com.fasterxml.jackson.annotation;
+
+	requires com.fasterxml.jackson.core;
+
+	requires com.fasterxml.jackson.databind;
+
+	requires com.google.gson;
+
+	requires java.desktop;
+
+	requires javassist;
+}

--- a/src/test/java/com/jsoniter/IterImplForStreamingTest.java
+++ b/src/test/java/com/jsoniter/IterImplForStreamingTest.java
@@ -6,8 +6,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import junit.framework.TestCase;
+import org.apache.commons.lang3.NotImplementedException;
 import org.junit.experimental.categories.Category;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public class IterImplForStreamingTest extends TestCase {
 
@@ -77,7 +77,7 @@ public class IterImplForStreamingTest extends TestCase {
 
 			@Override
 			public int read() throws IOException {
-				throw new NotImplementedException();
+				throw new NotImplementedException(new Exception());
 			}
 
 			@Override

--- a/src/test/java/com/jsoniter/SimpleRecord.java
+++ b/src/test/java/com/jsoniter/SimpleRecord.java
@@ -1,0 +1,11 @@
+package com.jsoniter;
+
+public record SimpleRecord(String field1, String field2) {
+    public SimpleRecord() {
+        this(null, null);
+    }
+    public SimpleRecord(String field1, String field2) {
+        this.field1 = field1;
+        this.field2 = field2;
+    }
+}

--- a/src/test/java/com/jsoniter/TestRecord.java
+++ b/src/test/java/com/jsoniter/TestRecord.java
@@ -9,8 +9,10 @@ import com.jsoniter.spi.JsonException;
 import junit.framework.TestCase;
 
 import java.io.IOException;
-import java.lang.reflect.*;
-import java.util.Arrays;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Map;
 
 public class TestRecord extends TestCase {
@@ -190,6 +192,7 @@ public class TestRecord extends TestCase {
         record TestRecord6(long val) {
 
             public TestRecord6(int valInt) {
+
                 this(Long.valueOf(valInt));
             }
         }
@@ -208,6 +211,7 @@ public class TestRecord extends TestCase {
 
             @JsonCreator
             public TestRecord6(@JsonProperty("valInt") int valInt) {
+
                 this(Long.valueOf(valInt));
             }
         }

--- a/src/test/java/com/jsoniter/TestRecord.java
+++ b/src/test/java/com/jsoniter/TestRecord.java
@@ -25,7 +25,8 @@ public class TestRecord extends TestCase {
         }
     }
 
-    public void test_print_record_reflection_info() {
+    // remove "disabled" to run the function
+    public void disabled_test_print_record_reflection_info() {
 
         Class<TestRecord1> clazz = TestRecord1.class;
 

--- a/src/test/java/com/jsoniter/TestRecord.java
+++ b/src/test/java/com/jsoniter/TestRecord.java
@@ -9,10 +9,8 @@ import com.jsoniter.spi.JsonException;
 import junit.framework.TestCase;
 
 import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
+import java.lang.reflect.*;
+import java.util.Arrays;
 import java.util.Map;
 
 public class TestRecord extends TestCase {
@@ -198,6 +196,22 @@ public class TestRecord extends TestCase {
         assertEquals(ReflectionRecordDecoder.OnlyFieldRecord.class, ReflectionDecoderFactory.create(new ClassInfo(TestRecord6.class)).getClass());
 
         JsonIterator iter = JsonIterator.parse("{ 'val' : 1 }".replace('\'', '"'));
+        TestRecord6 record = iter.read(TestRecord6.class);
+
+        assertNotNull(record);
+    }
+
+    public void test_record_2_constructors_secondCtorUse_withOnlyFieldDecoder() throws IOException {
+
+        record TestRecord6(long val) {
+
+            @JsonCreator
+            public TestRecord6(@JsonProperty("valInt") int valInt) {
+                this(Long.valueOf(valInt));
+            }
+        }
+
+        JsonIterator iter = JsonIterator.parse("{ 'valInt' : 1 }".replace('\'', '"'));
         TestRecord6 record = iter.read(TestRecord6.class);
 
         assertNotNull(record);

--- a/src/test/java/com/jsoniter/TestRecord.java
+++ b/src/test/java/com/jsoniter/TestRecord.java
@@ -1,31 +1,224 @@
 package com.jsoniter;
 
-import com.jsoniter.output.JsonStream;
+
+import com.jsoniter.annotation.JsonCreator;
+import com.jsoniter.annotation.JsonProperty;
+import com.jsoniter.any.Any;
+import com.jsoniter.spi.ClassInfo;
+import com.jsoniter.spi.EmptyExtension;
 import com.jsoniter.spi.JsonException;
-import junit.framework.Test;
+import com.jsoniter.spi.JsoniterSpi;
 import junit.framework.TestCase;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Map;
 
 public class TestRecord extends TestCase {
 
-    record TestRecord1(long field1) {
+    record TestRecord1(long field1) {}
 
+    public record TestRecord0(Long id, String name) {
+
+        public TestRecord0() {
+
+            this(0L, "");
+        }
+    }
+
+    public void test_print_record_reflection_info() {
+
+        Class<TestRecord1> clazz = TestRecord1.class;
+
+        System.out.println("Record Constructors :");
+        for (Constructor<?> constructor : clazz.getConstructors()) {
+            System.out.println(constructor);
+        }
+
+        System.out.println("Record Methods : ");
+        for (Method method : clazz.getMethods()) {
+            System.out.println(method);
+        }
+
+        System.out.println("Record Fields : ");
+        for (Field field : clazz.getFields()) {
+            System.out.println(field);
+            System.out.println("    modifiers : " + Modifier.toString(field.getModifiers()));
+        }
+
+        System.out.println("Record Declared Fields : ");
+        for (Field field : clazz.getDeclaredFields()) {
+            System.out.println(field);
+            System.out.println("    modifiers : " + Modifier.toString(field.getModifiers()));
+        }
+
+        try {
+            System.out.println("Record Default Declared Constructor : " + clazz.getDeclaredConstructor());
+        } catch (Exception ex) {
+            System.err.println("No Record Default Declared Constructor!");
+        }
+
+        System.out.println("Record Declared Constructors : ");
+        for (Constructor<?> constructor : clazz.getDeclaredConstructors()) {
+            System.out.println(constructor);
+            System.out.println("    name : " + constructor.getName());
+            System.out.println("    modifiers : " + Modifier.toString(constructor.getModifiers()));
+            System.out.println("    input count : " + constructor.getParameterCount());
+            System.out.println("    input types : ");
+            for (Class<?> parameter : constructor.getParameterTypes())
+                System.out.println("        " + parameter);
+        }
+    }
+
+    public void test_empty_record() throws IOException {
+
+        JsonIterator iter = JsonIterator.parse("{}");
+        assertNotNull(iter.read(TestRecord0.class));
+    }
+
+    public void test_empty_simple_record() throws IOException {
+
+        JsonIterator iter = JsonIterator.parse("{}");
+        SimpleRecord simpleRecord = iter.read(SimpleRecord.class);
+        assertNull(simpleRecord.field1());
+        iter.reset(iter.buf);
+        Object obj = iter.read(Object.class);
+        assertEquals(0, ((Map) obj).size());
+        iter.reset(iter.buf);
+        Any any = iter.readAny();
+        assertEquals(0, any.size());
     }
 
     public void test_record_error() throws IOException {
 
-        JsonIterator iter = JsonIterator.parse("{ 'field1' : 1".replace('\'', '"'));
-        try{
+        JsonIterator iter = JsonIterator.parse("{ 'field1' : 1 }".replace('\'', '"'));
+        try {
             TestRecord1 rec = iter.read(TestRecord1.class);
             assertEquals(1, rec.field1);
-        }catch (JsonException e) {
+        } catch (JsonException e) {
             throw new JsonException("no constructor for: class com.jsoniter.TestRecord", e);
         }
     }
 
-    public void test_record_serialize(){
-        assertEquals("{\"field1\":1}",JsonStream.serialize(new TestRecord1(1)));
+
+    public void test_record_withOnlyFieldDecoder() throws IOException {
+
+        assertEquals(ReflectionRecordDecoder.OnlyFieldRecord.class, ReflectionDecoderFactory.create(new ClassInfo(TestRecord1.class)).getClass());
+
+        JsonIterator iter = JsonIterator.parse("{ 'field1' : 1 }".replace('\'', '"'));
+        TestRecord1 record = iter.read(TestRecord1.class);
+
+        assertEquals(1, record.field1);
+    }
+
+    public void test_record_2_fields_withOnlyFieldDecoder() throws IOException {
+
+        record TestRecord2(long field1, String field2) {}
+
+        assertEquals(ReflectionRecordDecoder.OnlyFieldRecord.class, ReflectionDecoderFactory.create(new ClassInfo(TestRecord2.class)).getClass());
+
+        JsonIterator iter = JsonIterator.parse("{ 'field1' : 1, 'field2' : 'hey' }".replace('\'', '"'));
+        TestRecord2 record = iter.read(TestRecord2.class);
+
+        assertEquals(1, record.field1);
+        assertEquals("hey", record.field2);
+    }
+
+    public void test_record_2_fields_swapFieldOrder_withOnlyFieldDecoder() throws IOException {
+
+        record TestRecord2(String field2, long field1) {}
+
+        assertEquals(ReflectionRecordDecoder.OnlyFieldRecord.class, ReflectionDecoderFactory.create(new ClassInfo(TestRecord2.class)).getClass());
+
+        JsonIterator iter = JsonIterator.parse("{ 'field2' : 'hey', 'field1' : 1 }".replace('\'', '"'));
+        TestRecord2 record = iter.read(TestRecord2.class);
+
+        assertEquals(1, record.field1);
+        assertEquals("hey", record.field2);
+    }
+
+    public void test_record_recordComposition_withOnlyFieldDecoder() throws IOException {
+
+        record TestRecordA(long fieldA) {}
+        record TestRecordB(long fieldB, TestRecordA a) {}
+
+        assertEquals(ReflectionRecordDecoder.OnlyFieldRecord.class, ReflectionDecoderFactory.create(new ClassInfo(TestRecordB.class)).getClass());
+
+        JsonIterator iter = JsonIterator.parse("{ 'fieldB' : 1, 'a' : { 'fieldA' : 69 } }".replace('\'', '"'));
+        TestRecordB record = iter.read(TestRecordB.class);
+
+        assertEquals(1, record.fieldB);
+        assertEquals(69, record.a.fieldA);
+    }
+
+    public void test_record_empty_constructor_withOnlyFieldDecoder() throws IOException {
+
+        record TestRecord3() {}
+
+        assertEquals(ReflectionRecordDecoder.OnlyFieldRecord.class, ReflectionDecoderFactory.create(new ClassInfo(TestRecord3.class)).getClass());
+
+        JsonIterator iter = JsonIterator.parse("{ 'fieldB' : 1, 'a' : { 'fieldA' : 69 } }".replace('\'', '"'));
+        TestRecord3 record = iter.read(TestRecord3.class);
+
+        assertNotNull(record);
+    }
+
+    public void test_enum() throws IOException {
+
+        record TestRecord5(MyEnum field1) {
+
+            enum MyEnum {
+                HELLO,
+                WOW
+            }
+        }
+
+        TestRecord5 obj = JsonIterator.deserialize("{\"field1\":\"HELLO\"}", TestRecord5.class);
+        assertEquals(TestRecord5.MyEnum.HELLO, obj.field1);
+        try {
+            JsonIterator.deserialize("{\"field1\":\"HELLO1\"}", TestRecord5.class);
+            fail();
+        } catch (JsonException e) {
+        }
+        obj = JsonIterator.deserialize("{\"field1\":null}", TestRecord5.class);
+        assertNull(obj.field1);
+        obj = JsonIterator.deserialize("{\"field1\":\"WOW\"}", TestRecord5.class);
+        assertEquals(TestRecord5.MyEnum.WOW, obj.field1);
+    }
+
+    public void test_record_2_constructors_withOnlyFieldDecoder() throws IOException {
+
+        record TestRecord6(long val) {
+
+            public TestRecord6(int valInt) {
+                this(Long.valueOf(valInt));
+            }
+        }
+
+        assertEquals(ReflectionRecordDecoder.OnlyFieldRecord.class, ReflectionDecoderFactory.create(new ClassInfo(TestRecord6.class)).getClass());
+
+        JsonIterator iter = JsonIterator.parse("{ 'valInt' : 1 }".replace('\'', '"'));
+        TestRecord6 record = iter.read(TestRecord6.class);
+
+        assertNotNull(record);
+    }
+
+    public void test_record_withCtorDecoder() throws IOException {
+
+        record TestRecord2(@JsonProperty long field1) {
+
+            @JsonCreator
+            TestRecord2 {}
+        }
+
+        assertEquals(ReflectionDecoderFactory.create(new ClassInfo(TestRecord2.class)).getClass(), ReflectionObjectDecoder.WithCtor.class);
+
+        JsonIterator iter = JsonIterator.parse("{ 'field1' : 1 }".replace('\'', '"'));
+        TestRecord2 record = iter.read(TestRecord2.class);
+
+        assertEquals(1, record.field1);
     }
 }

--- a/src/test/java/com/jsoniter/TestRecord.java
+++ b/src/test/java/com/jsoniter/TestRecord.java
@@ -4,6 +4,7 @@ package com.jsoniter;
 import com.jsoniter.annotation.JsonCreator;
 import com.jsoniter.annotation.JsonProperty;
 import com.jsoniter.any.Any;
+import com.jsoniter.spi.ClassDescriptor;
 import com.jsoniter.spi.ClassInfo;
 import com.jsoniter.spi.JsonException;
 import junit.framework.TestCase;
@@ -17,7 +18,8 @@ import java.util.Map;
 
 public class TestRecord extends TestCase {
 
-    record TestRecord1(long field1) {}
+    record TestRecord1(long field1) {
+    }
 
     public record TestRecord0(Long id, String name) {
 
@@ -114,7 +116,8 @@ public class TestRecord extends TestCase {
 
     public void test_record_2_fields_withOnlyFieldDecoder() throws IOException {
 
-        record TestRecord2(long field1, String field2) {}
+        record TestRecord2(long field1, String field2) {
+        }
 
         assertEquals(ReflectionRecordDecoder.OnlyFieldRecord.class, ReflectionDecoderFactory.create(new ClassInfo(TestRecord2.class)).getClass());
 
@@ -127,7 +130,8 @@ public class TestRecord extends TestCase {
 
     public void test_record_2_fields_swapFieldOrder_withOnlyFieldDecoder() throws IOException {
 
-        record TestRecord2(String field2, long field1) {}
+        record TestRecord2(String field2, long field1) {
+        }
 
         assertEquals(ReflectionRecordDecoder.OnlyFieldRecord.class, ReflectionDecoderFactory.create(new ClassInfo(TestRecord2.class)).getClass());
 
@@ -140,8 +144,10 @@ public class TestRecord extends TestCase {
 
     public void test_record_recordComposition_withOnlyFieldDecoder() throws IOException {
 
-        record TestRecordA(long fieldA) {}
-        record TestRecordB(long fieldB, TestRecordA a) {}
+        record TestRecordA(long fieldA) {
+        }
+        record TestRecordB(long fieldB, TestRecordA a) {
+        }
 
         assertEquals(ReflectionRecordDecoder.OnlyFieldRecord.class, ReflectionDecoderFactory.create(new ClassInfo(TestRecordB.class)).getClass());
 
@@ -154,7 +160,8 @@ public class TestRecord extends TestCase {
 
     public void test_record_empty_constructor_withOnlyFieldDecoder() throws IOException {
 
-        record TestRecord3() {}
+        record TestRecord3() {
+        }
 
         assertEquals(ReflectionRecordDecoder.OnlyFieldRecord.class, ReflectionDecoderFactory.create(new ClassInfo(TestRecord3.class)).getClass());
 
@@ -216,6 +223,8 @@ public class TestRecord extends TestCase {
             }
         }
 
+        assertEquals(ReflectionRecordDecoder.WithCtor.class, ReflectionDecoderFactory.create(new ClassInfo(TestRecord6.class)).getClass());
+
         JsonIterator iter = JsonIterator.parse("{ 'valInt' : 1 }".replace('\'', '"'));
         TestRecord6 record = iter.read(TestRecord6.class);
 
@@ -227,8 +236,10 @@ public class TestRecord extends TestCase {
         record TestRecord2(@JsonProperty long field1) {
 
             @JsonCreator
-            TestRecord2 {}
+            TestRecord2 {
+            }
         }
+        assertEquals(ReflectionRecordDecoder.WithCtor.class, ReflectionDecoderFactory.create(new ClassInfo(TestRecord2.class)).getClass());
 
         assertEquals(ReflectionDecoderFactory.create(new ClassInfo(TestRecord2.class)).getClass(), ReflectionObjectDecoder.WithCtor.class);
 
@@ -237,4 +248,11 @@ public class TestRecord extends TestCase {
 
         assertEquals(1, record.field1);
     }
+
+    public void test_record_constructor() throws IOException {
+        ClassDescriptor desc = ClassDescriptor.getDecodingClassDescriptor(new ClassInfo(TestRecord0.class), false);
+        assertEquals(TestRecord0.class.getConstructors()[1], desc.ctor.ctor);
+
+    }
+
 }

--- a/src/test/java/com/jsoniter/TestRecord.java
+++ b/src/test/java/com/jsoniter/TestRecord.java
@@ -5,9 +5,7 @@ import com.jsoniter.annotation.JsonCreator;
 import com.jsoniter.annotation.JsonProperty;
 import com.jsoniter.any.Any;
 import com.jsoniter.spi.ClassInfo;
-import com.jsoniter.spi.EmptyExtension;
 import com.jsoniter.spi.JsonException;
-import com.jsoniter.spi.JsoniterSpi;
 import junit.framework.TestCase;
 
 import java.io.IOException;
@@ -102,7 +100,6 @@ public class TestRecord extends TestCase {
             throw new JsonException("no constructor for: class com.jsoniter.TestRecord", e);
         }
     }
-
 
     public void test_record_withOnlyFieldDecoder() throws IOException {
 
@@ -200,7 +197,7 @@ public class TestRecord extends TestCase {
 
         assertEquals(ReflectionRecordDecoder.OnlyFieldRecord.class, ReflectionDecoderFactory.create(new ClassInfo(TestRecord6.class)).getClass());
 
-        JsonIterator iter = JsonIterator.parse("{ 'valInt' : 1 }".replace('\'', '"'));
+        JsonIterator iter = JsonIterator.parse("{ 'val' : 1 }".replace('\'', '"'));
         TestRecord6 record = iter.read(TestRecord6.class);
 
         assertNotNull(record);

--- a/src/test/java/com/jsoniter/TestRecord.java
+++ b/src/test/java/com/jsoniter/TestRecord.java
@@ -1,0 +1,18 @@
+package com.jsoniter;
+
+import junit.framework.TestCase;
+
+import java.io.IOException;
+
+public class TestRecord extends TestCase {
+
+    record TestRecord1(long field1) {
+
+    }
+
+    public void test_record_error() throws IOException {
+
+        JsonIterator iter = JsonIterator.parse("{ 'field1' : 1".replace('\'', '"'));
+        iter.read(TestRecord1.class);
+    }
+}

--- a/src/test/java/com/jsoniter/TestRecord.java
+++ b/src/test/java/com/jsoniter/TestRecord.java
@@ -1,5 +1,7 @@
 package com.jsoniter;
 
+import com.jsoniter.output.JsonStream;
+import junit.framework.Test;
 import junit.framework.TestCase;
 
 import java.io.IOException;
@@ -14,5 +16,9 @@ public class TestRecord extends TestCase {
 
         JsonIterator iter = JsonIterator.parse("{ 'field1' : 1".replace('\'', '"'));
         iter.read(TestRecord1.class);
+    }
+
+    public void test_record_serialize(){
+        assertEquals("{\"field1\":1}",JsonStream.serialize(new TestRecord1(1)));
     }
 }

--- a/src/test/java/com/jsoniter/TestRecord.java
+++ b/src/test/java/com/jsoniter/TestRecord.java
@@ -1,10 +1,12 @@
 package com.jsoniter;
 
 import com.jsoniter.output.JsonStream;
+import com.jsoniter.spi.JsonException;
 import junit.framework.Test;
 import junit.framework.TestCase;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 public class TestRecord extends TestCase {
 
@@ -15,7 +17,12 @@ public class TestRecord extends TestCase {
     public void test_record_error() throws IOException {
 
         JsonIterator iter = JsonIterator.parse("{ 'field1' : 1".replace('\'', '"'));
-        iter.read(TestRecord1.class);
+        try{
+            TestRecord1 rec = iter.read(TestRecord1.class);
+            assertEquals(1, rec.field1);
+        }catch (JsonException e) {
+            throw new JsonException("no constructor for: class com.jsoniter.TestRecord", e);
+        }
     }
 
     public void test_record_serialize(){

--- a/src/test/java/com/jsoniter/any/TestRecord.java
+++ b/src/test/java/com/jsoniter/any/TestRecord.java
@@ -1,0 +1,55 @@
+package com.jsoniter.any;
+import junit.framework.TestCase;
+
+import java.util.*;
+
+public class TestRecord extends TestCase {
+
+    record TestRecord1(int field1) {
+
+    }
+
+    public void test_wrap_int(){
+        Any any = Any.wrap(new TestRecord1(3));
+        assertEquals(3, any.get("field1").toInt());
+    }
+
+    record TestRecord2(int field1, String field2) {
+
+    }
+
+    public void test_iterator(){
+        Any any = Any.wrap(new TestRecord2(3,"hej"));
+        Any.EntryIterator iter = any.entries();
+        HashMap<String, Object> map = new HashMap<String, Object>();
+        while (iter.next()) {
+            if(iter.key() == "field1"){
+                assertEquals(3,iter.value().toInt());
+            }
+            if(iter.key() == "field2"){
+                assertEquals("hej",iter.value().toString());
+            }
+        }
+    }
+
+    public void test_size() {
+        Any any = Any.wrap(new TestRecord2(7,"ho"));
+        assertEquals(2, any.size());
+    }
+
+    public void test_to_string() {
+        assertEquals("{\"field1\":7,\"field2\":\"hej\"}", Any.wrap(new TestRecord2(7,"hej")).toString());
+    }
+
+    record TestRecord3(){
+
+    }
+
+    public void test_to_boolean() {
+        Any any = Any.wrap(new TestRecord3());
+        assertFalse(any.toBoolean());
+        any = Any.wrap(new TestRecord2(1,"hallo"));
+        assertTrue(any.toBoolean());
+    }
+
+}

--- a/src/test/java/com/jsoniter/output/TestNested.java
+++ b/src/test/java/com/jsoniter/output/TestNested.java
@@ -1,16 +1,12 @@
 package com.jsoniter.output;
 
-import com.jsoniter.annotation.JsonProperty;
-import com.jsoniter.spi.JsoniterSpi;
-import com.jsoniter.spi.TypeLiteral;
-import junit.framework.TestCase;
+import java.io.*;
+import java.util.*;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.jsoniter.annotation.JsonProperty;
+import com.jsoniter.spi.*;
+
+import junit.framework.TestCase;
 
 public class TestNested extends TestCase {
 
@@ -45,7 +41,7 @@ public class TestNested extends TestCase {
         obj1.field1 = "1";
         obj1.field2 = "2";
         String output = JsonStream.serialize(new TypeLiteral<List<TestObject1>>() {
-        }, new ArrayList() {{
+        }, new ArrayList<>() {{
             add(obj1);
         }});
         assertTrue(output.contains("field1"));
@@ -92,7 +88,7 @@ public class TestNested extends TestCase {
             obj1.field1 = "1";
             obj1.field2 = "2";
             stream.writeVal(new TypeLiteral<Map<String, TestObject1>>() {
-            }, new HashMap() {{
+            }, new HashMap<>() {{
                 put("hello", obj1);
             }});
             stream.close();

--- a/src/test/java/com/jsoniter/output/TestRecord.java
+++ b/src/test/java/com/jsoniter/output/TestRecord.java
@@ -1,0 +1,39 @@
+package com.jsoniter.output;
+
+import junit.framework.TestCase;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.*;
+
+public class TestRecord  extends TestCase {
+    private ByteArrayOutputStream baos;
+    private JsonStream stream;
+
+    public void setUp() {
+        baos = new ByteArrayOutputStream();
+        stream = new JsonStream(baos, 4096);
+    }
+
+    record TestRecord1(float field1){
+
+    }
+
+    public void test_gen_record() throws IOException {
+        stream.writeVal(new TestRecord1(2.5f));
+        stream.close();
+        assertEquals("{'field1':2.5}".replace('\'', '"'), baos.toString());
+    }
+
+    record TestRecord2(){
+
+    }
+
+    public void test_empty_record() throws IOException {
+        stream.writeVal(new TestRecord2());
+        stream.close();
+        assertEquals("{}".replace('\'', '"'), baos.toString());
+    }
+
+
+
+}

--- a/src/test/java/com/jsoniter/suite/AllTestCases.java
+++ b/src/test/java/com/jsoniter/suite/AllTestCases.java
@@ -6,6 +6,7 @@ import com.jsoniter.TestGenerics;
 import com.jsoniter.TestGson;
 import com.jsoniter.TestNested;
 import com.jsoniter.TestObject;
+import com.jsoniter.TestRecord;
 import com.jsoniter.TestString;
 import com.jsoniter.any.TestList;
 import com.jsoniter.any.TestLong;
@@ -58,6 +59,10 @@ import org.junit.runners.Suite;
         TestList.class,
         TestAnnotationJsonObject.class,
         TestLong.class,
-        TestOmitValue.class})
+        TestOmitValue.class,
+        TestRecord.class,
+        com.jsoniter.output.TestRecord.class,
+        com.jsoniter.any.TestRecord.class
+})
 public abstract class AllTestCases {
 }


### PR DESCRIPTION
* Forked from [noahra/java](https://github.com/noahra/java) who added support for record classes.
* Updated Version to Java 17 (LTS)
* Added a ```module-info.java``` file so it can be used on the module-path without having a an unstable "automatic" module name.
* Updated some dependencies and plugins to newer version.
* Did not fix the old failing tests.

TODO: If you merge this, you should probably update the library version in the pom.xml file.


