### PR TITLE
enhance null handling to check case 'n' in issue 357

### DIFF
--- a/src/main/java/com/jsoniter/IterImpl.java
+++ b/src/main/java/com/jsoniter/IterImpl.java
@@ -189,8 +189,13 @@ class IterImpl {
                 skipFixedBytes(iter, 4);
                 return Any.wrap(false);
             case 'n':
-                skipFixedBytes(iter, 3);
-                return Any.wrap((Object) null);
+                if (readByte(iter) == 'u' &&
+                    readByte(iter) == 'l' &&
+                    readByte(iter) == 'l') {
+                    return Any.wrap((Object) null);
+                } else {
+                    throw iter.reportError("readAny", "expected 'null' but found something else");
+                }
             case '[':
                 skipArray(iter);
                 return Any.lazyArray(iter.buf, start, iter.head);

--- a/src/main/java/com/jsoniter/IterImplForStreaming.java
+++ b/src/main/java/com/jsoniter/IterImplForStreaming.java
@@ -334,9 +334,15 @@ class IterImplForStreaming {
                 iter.skipStartedAt = -1;
                 return Any.wrap(false);
             case 'n':
-                skipFixedBytes(iter, 3);
-                iter.skipStartedAt = -1;
-                return Any.wrap((Object) null);
+                if (nextToken(iter) == 'u' &&
+                    nextToken(iter) == 'l' &&
+                    nextToken(iter) == 'l') {
+                        
+                    iter.skipStartedAt = -1;
+                    return Any.wrap((Object) null);
+                } else {
+                    throw iter.reportError("readAny", "expected 'null' but found something else");
+                }
             case '[':
                 skipArray(iter);
                 copied = copySkippedBytes(iter);

--- a/src/main/java/com/jsoniter/IterImplObject.java
+++ b/src/main/java/com/jsoniter/IterImplObject.java
@@ -8,8 +8,12 @@ class IterImplObject {
         byte c = IterImpl.nextToken(iter);
         switch (c) {
             case 'n':
-                IterImpl.skipFixedBytes(iter, 3);
-                return null;
+                if (IterImpl.readByte(iter) == 'u' &&
+                    IterImpl.readByte(iter) == 'l' &&
+                    IterImpl.readByte(iter) == 'l') {
+                    return null; 
+                }
+                throw iter.reportError("readObject", "expected 'null' but found something else");
             case '{':
                 c = IterImpl.nextToken(iter);
                 if (c == '"') {

--- a/src/main/java/com/jsoniter/IterImplSkip.java
+++ b/src/main/java/com/jsoniter/IterImplSkip.java
@@ -37,8 +37,13 @@ class IterImplSkip {
                 return;
             case 't':
             case 'n':
-                IterImpl.skipFixedBytes(iter, 3); // true or null
-                return;
+                if (IterImpl.readByte(iter) == 'u' &&
+                    IterImpl.readByte(iter) == 'l' &&
+                    IterImpl.readByte(iter) == 'l') {
+                    return;  
+                } else {
+                    throw iter.reportError("skip", "expected 'null' but found something else");
+                }
             case 'f':
                 IterImpl.skipFixedBytes(iter, 4); // false
                 return;


### PR DESCRIPTION
I updated the jump logic to handle 'n' characters, ensuring that only the sequence "null" is recognized as a null value.
I implemented additional checks to prevent incorrect values ​​from being interpreted as null.